### PR TITLE
remove schema from URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,13 @@ The implementation class of `java.sql.Driver` is `com.hazelcast.jdbc.Driver` and
 ## Connection URL
 The format of the URL must have the following structure, parts in `[]` are optional:
 ```
-jdbc:hazelcast://host[:port][,host[:port]...]/schema[?property1=value1[&property2=value2]...]
+jdbc:hazelcast://host[:port][,host[:port]...]/[?property1=value1[&property2=value2]...]
 ```
 where:
 **jdbc:hazelcast:**: (Required) is a sub-protocol and is a constant.
 **host**: (Required) server address (or addresses separated with comma) to connect to, or the cluster name if the server is 
 Hazelcast Cloud
 **port**: (Optional) Server port. Defaults to 5701.
-**schema**: (Required) Hazelcast schema name.
 **propertyN**: (Optional) List of connection properties in the key-value form.
 
 ### Connection properties
@@ -135,7 +134,7 @@ The following list contains the properties supported by the `Hazelcast JDBC Driv
 
 #### Hazelcast Cloud Configuration
 For connecting to the Hazelcast cloud you only need to specify `discoveryToken` property and use the `cluster-name` as a host in 
-the URL: `jdbc:hazelcast://<cluster-name>/<schema>?discoveryToken=<yourDiscoveryToken>`.
+the URL: `jdbc:hazelcast://<cluster-name>/?discoveryToken=<yourDiscoveryToken>`.
 
 #### Additional Configuration
 Besides URL, it is possible to use [Hazelcast Declarative Configuration](https://docs.hazelcast.com/imdg/4.1.2/configuration/configuring-declaratively.html) and  [Overriding Configuration](https://docs.hazelcast.com/imdg/4.2-beta-1/configuration/overriding-configuration-settings) to configure [Hazelcast Java Client](https://docs.hazelcast.com/imdg/4.2-beta-1/clients/java)

--- a/src/main/java/com/hazelcast/jdbc/Driver.java
+++ b/src/main/java/com/hazelcast/jdbc/Driver.java
@@ -50,9 +50,7 @@ public class Driver implements java.sql.Driver {
             // convert to SQLException
             throw new SQLException(e.getMessage(), e);
         }
-        JdbcConnection jdbcConnection = new JdbcConnection(new HazelcastSqlClient(jdbcUrl));
-        jdbcConnection.setSchema(jdbcUrl.getSchema());
-        return jdbcConnection;
+        return new JdbcConnection(new HazelcastSqlClient(jdbcUrl));
     }
 
     @Override

--- a/src/main/java/com/hazelcast/jdbc/JdbcUrl.java
+++ b/src/main/java/com/hazelcast/jdbc/JdbcUrl.java
@@ -28,12 +28,10 @@ final class JdbcUrl {
 
     private static final String PREFIX = "jdbc:hazelcast:";
     private static final Pattern JDBC_URL_PATTERN = Pattern.compile(PREFIX + "//"
-            + "(?<authority>\\S+?(?=[/]))"
-            + "/(?<schema>\\S+?)"
+            + "(?<authority>\\S+?)/?"
             + "(\\?(?<parameters>\\S*))?");
 
     private final List<String> authorities;
-    private final String schema;
     private final String rawUrl;
     private final Properties properties = new Properties();
     private final String rawAuthority;
@@ -42,12 +40,11 @@ final class JdbcUrl {
         Matcher matcher = JDBC_URL_PATTERN.matcher(url);
         if (!matcher.matches()) {
             throw new IllegalArgumentException("The URL doesn't match the structure - "
-                    + "jdbc:hazelcast://host:port[,host2:port...]/schema[?prop1=value1&...]");
+                    + "jdbc:hazelcast://host:port[,host2:port...]/[?prop1=value1&...]");
         }
 
         this.rawAuthority = decodeUrl(matcher.group("authority"));
         this.authorities = Arrays.asList(rawAuthority.split(","));
-        this.schema = decodeUrl(matcher.group("schema"));
         this.rawUrl = url;
 
         if (properties != null) {
@@ -68,10 +65,6 @@ final class JdbcUrl {
 
     public List<String> getAuthorities() {
         return authorities;
-    }
-
-    public String getSchema() {
-        return schema;
     }
 
     public String getProperty(String key) {

--- a/src/test/java/com/hazelcast/jdbc/DriverImdgTest.java
+++ b/src/test/java/com/hazelcast/jdbc/DriverImdgTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DriverImdgTest {
 
-    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/public";
+    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701";
 
     private final Connection connection = DriverManager.getConnection(JDBC_HAZELCAST_LOCALHOST);
 
@@ -125,11 +125,6 @@ public class DriverImdgTest {
 
         assertThat(statement.isClosed()).isTrue();
         assertThat(resultSet.isClosed()).isTrue();
-    }
-
-    @Test
-    void shouldSupportSchemaFromConnectionString() throws SQLException {
-        assertThat(connection.getSchema()).isEqualTo("public");
     }
 
     @Test

--- a/src/test/java/com/hazelcast/jdbc/DriverTypeConversionTest.java
+++ b/src/test/java/com/hazelcast/jdbc/DriverTypeConversionTest.java
@@ -57,7 +57,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 class DriverTypeConversionTest {
 
-    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/public";
+    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/";
     private static HazelcastInstance member;
     private final Connection connection = DriverManager.getConnection(JDBC_HAZELCAST_LOCALHOST);
 

--- a/src/test/java/com/hazelcast/jdbc/HazelcastConfigFactoryTest.java
+++ b/src/test/java/com/hazelcast/jdbc/HazelcastConfigFactoryTest.java
@@ -36,7 +36,7 @@ class HazelcastConfigFactoryTest {
     @Test
     void shouldParseClusterNameConfiguration() {
         ClientConfig clientConfig = configFactory.clientConfig(
-                new JdbcUrl("jdbc:hazelcast://localhost:5701/public?clusterName=my-cluster", null));
+                new JdbcUrl("jdbc:hazelcast://localhost:5701/?clusterName=my-cluster", null));
         assertThat(clientConfig).isEqualTo(ClientConfig.load()
                 .setNetworkConfig(new ClientNetworkConfig().setAddresses(Collections.singletonList("localhost:5701")))
                 .setClusterName("my-cluster"));
@@ -45,7 +45,7 @@ class HazelcastConfigFactoryTest {
     @Test
     void shouldParseDiscoveryToken() {
         ClientConfig clientConfig = configFactory.clientConfig(
-                new JdbcUrl("jdbc:hazelcast://cluster-name/public?discoveryToken=token-value-123", null));
+                new JdbcUrl("jdbc:hazelcast://cluster-name/?discoveryToken=token-value-123", null));
         assertThat(clientConfig).isEqualTo(ClientConfig.load()
                 .setProperty(ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN.getName(), "token-value-123")
                 .setClusterName("cluster-name"));
@@ -54,7 +54,7 @@ class HazelcastConfigFactoryTest {
     @Test
     void shouldParseCredentials() {
         ClientConfig clientConfig = configFactory.clientConfig(
-                new JdbcUrl("jdbc:hazelcast://localhost:5701/public?user=admin&password=pass", null));
+                new JdbcUrl("jdbc:hazelcast://localhost:5701/?user=admin&password=pass", null));
         UsernamePasswordCredentials credentials = (UsernamePasswordCredentials) clientConfig.getSecurityConfig()
                 .getCredentialsIdentityConfig().getCredentials();
         assertThat(credentials.getName()).isEqualTo("admin");
@@ -65,7 +65,7 @@ class HazelcastConfigFactoryTest {
     @Test
     void shouldParseSslConfigs() {
         ClientConfig clientConfig = configFactory.clientConfig(
-                new JdbcUrl("jdbc:hazelcast://localhost:5701/public?sslEnabled=true&trustStore=truststore" +
+                new JdbcUrl("jdbc:hazelcast://localhost:5701/?sslEnabled=true&trustStore=truststore" +
                         "&trustStorePassword=123abc", null));
         ClientConfig expectedConfig = ClientConfig.load()
                 .setNetworkConfig(new ClientNetworkConfig()
@@ -81,7 +81,7 @@ class HazelcastConfigFactoryTest {
     @Test
     void shouldParseAwsConfigs() {
         ClientConfig clientConfig = configFactory.clientConfig(
-                new JdbcUrl("jdbc:hazelcast://localhost:5701/public?awsTagKey=tagkey&awsTagValue=tagValue" +
+                new JdbcUrl("jdbc:hazelcast://localhost:5701/?awsTagKey=tagkey&awsTagValue=tagValue" +
                         "&awsAccessKey=accessKey&awsSecretKey=secretKey&awsIamRole=ADMIN&awsRegion=us-west-2&awsHostHeader=ec2" +
                         "&awsSecurityGroupName=securityGroup&awsConnectionTimeoutSeconds=10&awsReadTimeoutSeconds=5" +
                         "&awsConnectionRetries=3&awsHzPort=5801-5808&awsUsePublicIp=true", null));
@@ -109,7 +109,7 @@ class HazelcastConfigFactoryTest {
     @Test
     void shouldParseGcpConfigs() {
         ClientConfig clientConfig = configFactory.clientConfig(
-                new JdbcUrl("jdbc:hazelcast://localhost:5701/public?gcpPrivateKeyPath=/home/name/service/account/key.json" +
+                new JdbcUrl("jdbc:hazelcast://localhost:5701/?gcpPrivateKeyPath=/home/name/service/account/key.json" +
                         "&gcpProjects=project-1,project-2&gcpRegion=us-east1&gcpHzPort=5701-5708" +
                         "&gcpLabel=application=hazelcast&gcpUsePublicIp=true", null));
         ClientConfig expectedConfig = ClientConfig.load()
@@ -130,7 +130,7 @@ class HazelcastConfigFactoryTest {
     @Test
     void shouldParseGcpConfigsWithMultipleLabels() {
         ClientConfig clientConfig = configFactory.clientConfig(
-                new JdbcUrl("jdbc:hazelcast://localhost:5701/public?gcpPrivateKeyPath=/home/name/service/account/key.json" +
+                new JdbcUrl("jdbc:hazelcast://localhost:5701/?gcpPrivateKeyPath=/home/name/service/account/key.json" +
                         "&gcpProjects=project-1,project-2&gcpRegion=us-east1&gcpHzPort=5701-5708" +
                         "&gcpLabel=application=hazelcast,other=value&gcpUsePublicIp=true", null));
         ClientConfig expectedConfig = ClientConfig.load()
@@ -151,7 +151,7 @@ class HazelcastConfigFactoryTest {
     @Test
     void shouldParseConfigsForMultipleMemberInstances() {
         ClientConfig clientConfig = configFactory.clientConfig(
-                new JdbcUrl("jdbc:hazelcast://198.51.100.11:5701,203.0.113.42:5702/public", null));
+                new JdbcUrl("jdbc:hazelcast://198.51.100.11:5701,203.0.113.42:5702/", null));
         assertThat(clientConfig).isEqualTo(ClientConfig.load()
                 .setNetworkConfig(new ClientNetworkConfig().setAddresses(Arrays.asList("198.51.100.11:5701", "203.0.113.42:5702")))
                 .setClusterName("dev"));
@@ -159,7 +159,7 @@ class HazelcastConfigFactoryTest {
 
     @Test
     void shouldDecodeUrlEncodedHost() {
-        ClientConfig clientConfig = configFactory.clientConfig(new JdbcUrl("jdbc:hazelcast://loc%61lhost:5701/public", null));
+        ClientConfig clientConfig = configFactory.clientConfig(new JdbcUrl("jdbc:hazelcast://loc%61lhost:5701/", null));
         assertThat(clientConfig).isEqualTo(ClientConfig.load()
                 .setNetworkConfig(new ClientNetworkConfig().setAddresses(Collections.singletonList("localhost:5701")))
                 .setClusterName("dev"));

--- a/src/test/java/com/hazelcast/jdbc/JdbcConnectionIntegrationTest.java
+++ b/src/test/java/com/hazelcast/jdbc/JdbcConnectionIntegrationTest.java
@@ -38,7 +38,7 @@ public class JdbcConnectionIntegrationTest {
     @BeforeEach
     public void setUp() {
         HazelcastInstance member = Hazelcast.newHazelcastInstance();
-        client = new HazelcastSqlClient(new JdbcUrl("jdbc:hazelcast://localhost:5701/public", null));
+        client = new HazelcastSqlClient(new JdbcUrl("jdbc:hazelcast://localhost:5701/", null));
 
         IMap<Integer, Person> personMap = member.getMap("person");
         for (int i = 0; i < 3; i++) {

--- a/src/test/java/com/hazelcast/jdbc/JdbcPreparedStatementTest.java
+++ b/src/test/java/com/hazelcast/jdbc/JdbcPreparedStatementTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JdbcPreparedStatementTest {
 
-    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/public";
+    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/";
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/com/hazelcast/jdbc/JdbcResultSetMetaDataTest.java
+++ b/src/test/java/com/hazelcast/jdbc/JdbcResultSetMetaDataTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JdbcResultSetMetaDataTest {
 
-    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/public";
+    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/";
 
     private final Connection connection = DriverManager.getConnection(JDBC_HAZELCAST_LOCALHOST);
 

--- a/src/test/java/com/hazelcast/jdbc/JdbcStatementQueryTypeTest.java
+++ b/src/test/java/com/hazelcast/jdbc/JdbcStatementQueryTypeTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class JdbcStatementQueryTypeTest {
 
-    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/public";
+    private static final String JDBC_HAZELCAST_LOCALHOST = "jdbc:hazelcast://localhost:5701/";
 
     Connection connection = DriverManager.getConnection(JDBC_HAZELCAST_LOCALHOST);
 

--- a/src/test/java/com/hazelcast/jdbc/JdbcUrlTest.java
+++ b/src/test/java/com/hazelcast/jdbc/JdbcUrlTest.java
@@ -27,7 +27,7 @@ class JdbcUrlTest {
 
     @Test
     void acceptsUrl_when_validUrl_then_true() {
-        assertThat(JdbcUrl.acceptsUrl("jdbc:hazelcast://localhost:5701/public")).isTrue();
+        assertThat(JdbcUrl.acceptsUrl("jdbc:hazelcast://localhost:5701/")).isTrue();
     }
 
     @Test
@@ -48,24 +48,22 @@ class JdbcUrlTest {
 
     @Test
     void test_propertyParsing() {
-        JdbcUrl url = new JdbcUrl("jdbc:hazelcast://localhost:5701/public?prop1=val1&prop2=val2", new Properties());
+        JdbcUrl url = new JdbcUrl("jdbc:hazelcast://localhost:5701/?prop1=val1&prop2=val2", new Properties());
 
         assertThat(url).isNotNull();
         assertThat(url.getAuthorities()).contains("localhost:5701");
-        assertThat(url.getSchema()).isEqualTo("public");
         assertThat(url.getProperty("prop1")).isEqualTo("val1");
 
-        JdbcUrl urlWithoutPort = new JdbcUrl("jdbc:hazelcast://clustername/public", new Properties());
+        JdbcUrl urlWithoutPort = new JdbcUrl("jdbc:hazelcast://clustername/", new Properties());
         assertThat(urlWithoutPort).isNotNull();
         assertThat(urlWithoutPort.getAuthorities()).contains("clustername");
     }
 
     @Test
     void test_propertyParsing_withEscaping() {
-        JdbcUrl url = new JdbcUrl("jdbc:hazelcast://local%68ost:5701/publi%63?a=%26&b%3d=c", new Properties());
+        JdbcUrl url = new JdbcUrl("jdbc:hazelcast://local%68ost:5701/?a=%26&b%3d=c", new Properties());
         assertThat(url).isNotNull();
         assertThat(url.getAuthorities()).containsExactly("localhost:5701");
-        assertThat(url.getSchema()).isEqualTo("public");
         assertThat(url.getProperty("a")).isEqualTo("&");
         assertThat(url.getProperty("b=")).isEqualTo("c");
     }
@@ -74,13 +72,13 @@ class JdbcUrlTest {
     public void when_sameKeyInUrlAndProperties_then_thatFromUrlTakesPrecedence() {
         Properties props = new Properties();
         props.setProperty("a", "foo");
-        JdbcUrl url = new JdbcUrl("jdbc:hazelcast://localhost/schema?a=bar", props);
+        JdbcUrl url = new JdbcUrl("jdbc:hazelcast://localhost/?a=bar", props);
         assertEquals("bar", url.getProperty("a"));
     }
 
     @Test
     public void when_duplicateKeyInUrl_then_lastOccurrenceUsed() {
-        JdbcUrl url = new JdbcUrl("jdbc:hazelcast://localhost/schema?a=foo&a=bar", null);
+        JdbcUrl url = new JdbcUrl("jdbc:hazelcast://localhost/?a=foo&a=bar", null);
         assertEquals("bar", url.getProperty("a"));
     }
 }


### PR DESCRIPTION
As long as in IMDG 4.2 schema support does not work because of a bug the presense of it in the URL is only make it more complex
The schema as optional part of the URL might be introduced in the next versions