### PR TITLE
Fixing nulls for all rows after first null.

### DIFF
--- a/src/main/java/com/hazelcast/jdbc/JdbcResultSet.java
+++ b/src/main/java/com/hazelcast/jdbc/JdbcResultSet.java
@@ -1144,9 +1144,7 @@ public class JdbcResultSet implements ResultSet {
 
     private <T> T getByIndex(int columnIndex) {
         T result = currentRow.getObject(columnIndex);
-        if (result == null) {
-            wasNull = true;
-        }
+        wasNull = result == null;
         return result;
     }
 


### PR DESCRIPTION
DBeaver presented strange nulls:
![image](https://user-images.githubusercontent.com/57556371/179791383-f6535649-e288-45bc-b7fe-4f5e7621da87.png)

Once the ```wasNull``` set to ```true``` it is never changed back to false.