### PR TITLE
Change dependency to EE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
+            <artifactId>hazelcast-enterprise</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 
@@ -128,7 +128,6 @@
             <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
-
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
With a dependency to Hazelcast OS, it doesn't work with EE clusters.