### PR TITLE
Include hazelcast-sql dependency in EE module [HZ-2737]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ out/
 atlassian-ide-plugin.xml
 
 hazelcast-jdbc.iml
+hazelcast-jdbc-root.iml
+hazelcast-jdbc-core/hazelcast-jdbc-core.iml
+hazelcast-jdbc-enterprise/hazelcast-jdbc-enterprise.iml

--- a/hazelcast-jdbc-enterprise/pom.xml
+++ b/hazelcast-jdbc-enterprise/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>hazelcast-enterprise</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-sql</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <hazelcast.version>5.3.0</hazelcast.version>
+        <hazelcast.version>5.3.1</hazelcast.version>
         <mockito.version>4.11.0</mockito.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
         <maven.findbugs.plugin.version>3.0.5</maven.findbugs.plugin.version>


### PR DESCRIPTION
Fixes https://hazelcast.atlassian.net/browse/HZ-2737

Also bumps the `hazelcast.version` to 5.3.1.