### PR TITLE
Add smoke tests to 'Release Version' workflow [HZ-2748]

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -16,6 +16,8 @@ env:
   GIT_AUTHOR_EMAIL: <>
   GIT_COMMITTER_NAME: GitHub Actions Bot
   GIT_COMMITTER_EMAIL: <>
+  CLUSTER_NAME: smoke-test
+  EE_CLUSTER_NAME: smoke-test-ee
 
 jobs:
   do-release:
@@ -26,11 +28,18 @@ jobs:
         image: hazelcast/hazelcast:latest-slim
         ports:
           - 6701:5701
+        env:
+          HZ_CLUSTERNAME: $CLUSTER_NAME
+          HZ_NETWORK_JOIN_MULTICAST_ENABLED: false
+          HZ_NETWORK_JOIN_TCPIP_ENABLED: true
       hazelcast-ee:
         image: hazelcast/hazelcast-enterprise:latest-slim
         ports:
           - 6702:5701
         env:
+          HZ_CLUSTERNAME: $EE_CLUSTER_NAME
+          HZ_NETWORK_JOIN_MULTICAST_ENABLED: false
+          HZ_NETWORK_JOIN_TCPIP_ENABLED: true
           HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
     name: Build and release version
     steps:
@@ -62,13 +71,13 @@ jobs:
         timeout-minutes: 2
         run: |
           mvn clean package -V -B -Psmoke-test -DskipTests
-          java -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc/target/hazelcast-jdbc-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6701
+          java -ea -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc/target/hazelcast-jdbc-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6701 $CLUSTER_NAME
 
       - name: Build and run ee smoke test
         timeout-minutes: 2
         run: |
           mvn clean package -V -B -Psmoke-test-ee -DskipTests
-          java -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc-enterprise/target/hazelcast-jdbc-enterprise-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6702
+          java -ea -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc-enterprise/target/hazelcast-jdbc-enterprise-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6702 $EE_CLUSTER_NAME
 
       - name: Deploy EE with Maven
         run: mvn -f hazelcast-jdbc-enterprise -V -B deploy -Djdbc-release -DskipTests -DskipStaging

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -27,7 +27,7 @@ jobs:
         ports:
           - 6701:5701
       hazelcast-ee:
-        image: hazelcast/hazelcast-enterprise
+        image: hazelcast/hazelcast-enterprise:latest-slim
         ports:
           - 6702:5701
         env:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -68,13 +68,11 @@ jobs:
           mvn clean install -V -B
 
       - name: Build and run smoke test
-        timeout-minutes: 2
         run: |
           mvn clean package -V -B -Psmoke-test -DskipTests
           java -ea -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc/target/hazelcast-jdbc-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6701 $CLUSTER_NAME
 
       - name: Build and run ee smoke test
-        timeout-minutes: 2
         run: |
           mvn clean package -V -B -Psmoke-test-ee -DskipTests
           java -ea -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc-enterprise/target/hazelcast-jdbc-enterprise-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6702 $EE_CLUSTER_NAME

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -31,7 +31,7 @@ jobs:
         ports:
           - 6702:5701
         env:
-          HZ_LICENSEKEY: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
+          HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
     name: Build and release version
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       hazelcast:
-        image: hazelcast/hazelcast
+        image: hazelcast/hazelcast:latest-slim
         ports:
           - 6701:5701
       hazelcast-ee:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -21,6 +21,17 @@ jobs:
   do-release:
     if: github.repository_owner == 'hazelcast'
     runs-on: ubuntu-latest
+    services:
+      hazelcast:
+        image: hazelcast/hazelcast
+        ports:
+          - 6701:5701
+      hazelcast-ee:
+        image: hazelcast/hazelcast-enterprise
+        ports:
+          - 6702:5701
+        env:
+          HZ_LICENSEKEY: ${{ secrets.HZ_ENTERPRISE_LICENSE }}
     name: Build and release version
     steps:
       - uses: actions/checkout@v3
@@ -46,6 +57,18 @@ jobs:
           git commit -am "Set version to ${{ github.event.inputs.release-version }}"
           git tag v${{ github.event.inputs.release-version }}
           mvn clean install -V -B
+
+      - name: Build and run smoke test
+        timeout-minutes: 2
+        run: |
+          mvn clean package -V -B -Psmoke-test -DskipTests
+          java -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc/target/hazelcast-jdbc-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6701
+
+      - name: Build and run ee smoke test
+        timeout-minutes: 2
+        run: |
+          mvn clean package -V -B -Psmoke-test-ee -DskipTests
+          java -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc-enterprise/target/hazelcast-jdbc-enterprise-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6702
 
       - name: Deploy EE with Maven
         run: mvn -f hazelcast-jdbc-enterprise -V -B deploy -Djdbc-release -DskipTests -DskipStaging

--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,24 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>smoke-test</id>
+            <modules>
+                <module>smoke-test</module>
+            </modules>
+            <properties>
+                <jdbcArtifact>hazelcast-jdbc</jdbcArtifact>
+            </properties>
+        </profile>
+        <profile>
+            <id>smoke-test-ee</id>
+            <modules>
+                <module>smoke-test</module>
+            </modules>
+            <properties>
+                <jdbcArtifact>hazelcast-jdbc-enterprise</jdbcArtifact>
+            </properties>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-jdbc-root</artifactId>
+        <version>5.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smoke-test</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>${jdbcArtifact}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-third-party</id>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <phase/>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/smoke-test/src/main/java/com/hazelcast/smoke/test/SmokeTestDriver.java
+++ b/smoke-test/src/main/java/com/hazelcast/smoke/test/SmokeTestDriver.java
@@ -13,12 +13,17 @@ public class SmokeTestDriver {
 
     public static void main(String[] args) throws SQLException {
 
-        String hzPort = "5701";
-        if (args.length > 0) {
-            hzPort = args[0];
+        if (args.length < 2) {
+            logger.severe("Usage: 'java "
+                    + SmokeTestDriver.class.getName()
+                    + " <port> <clusterName>");
+            throw new IllegalArgumentException("Too few arguments");
         }
 
-        try (Connection con = DriverManager.getConnection("jdbc:hazelcast://localhost:" + hzPort + "/")) {
+        String hzPort = args[0];
+        String clusterName = args[1];
+        try (Connection con = DriverManager.getConnection(
+                "jdbc:hazelcast://localhost:" + hzPort + "/?clusterName=" + clusterName)) {
             logger.info("Database: " + con.getMetaData().getDatabaseProductName()
                     + ": " + con.getMetaData().getDatabaseProductVersion());
 

--- a/smoke-test/src/main/java/com/hazelcast/smoke/test/SmokeTestDriver.java
+++ b/smoke-test/src/main/java/com/hazelcast/smoke/test/SmokeTestDriver.java
@@ -1,0 +1,61 @@
+package com.hazelcast.smoke.test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.logging.Logger;
+
+public class SmokeTestDriver {
+
+    private static final Logger logger = Logger.getLogger(SmokeTestDriver.class.getName());
+
+    public static void main(String[] args) throws SQLException {
+
+        String hzPort = "5701";
+        if (args.length > 0) {
+            hzPort = args[0];
+        }
+
+        try (Connection con = DriverManager.getConnection("jdbc:hazelcast://localhost:" + hzPort + "/")) {
+            logger.info("Database: " + con.getMetaData().getDatabaseProductName()
+                    + ": " + con.getMetaData().getDatabaseProductVersion());
+
+            try (Statement s = con.createStatement()) {
+                s.execute("CREATE OR REPLACE MAPPING map "
+                        + "TYPE IMap OPTIONS("
+                        + "  'keyFormat'='integer', "
+                        + "  'valueFormat'='varchar'"
+                        + ")");
+
+                int insertCount = s.executeUpdate(
+                        "INSERT INTO map "
+                        + "SELECT v, 'name-' || v "
+                        + "FROM TABLE(generate_series(0, 9))"
+                );
+                assert insertCount == 0;
+
+                ResultSet rs = s.executeQuery(
+                        "SELECT __key, this "
+                        + "FROM map "
+                        + "ORDER BY __key"
+                );
+                int rowCount = 0;
+                while (rs.next()) {
+                    String row = String.format("__key: %d value: %s",
+                            rs.getInt("__key"), rs.getString("this"));
+                    logger.info(row);
+                    rowCount++;
+                }
+
+                assert rowCount == 10;
+
+                int deleteCount = s.executeUpdate("DELETE FROM map");
+                assert deleteCount == insertCount;
+
+                s.execute("DROP MAPPING map");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds module to build and run a simple 'smoke test' during the release
deployment pipline. Runs separate steps for OS and EE jars.

~~Requires a new repository secret (`HZ_ENTERPRISE_LICENSE`) to run the HZ
EE service container.~~