### PR TITLE
Upgrade to Java 17 [HZ-4160]

### DIFF
--- a/.github/java-config.yml
+++ b/.github/java-config.yml
@@ -1,0 +1,2 @@
+java-version: "17"
+distribution: "adopt"

--- a/.github/java-config.yml
+++ b/.github/java-config.yml
@@ -1,2 +1,2 @@
 java-version: "17"
-distribution: "adopt"
+distribution: "temurin"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11' ]
+        java: [ '17' ]
         architecture: [ 'x64' ]
-        distribution: [ 'adopt' ]
+        distribution: [ 'temurin' ]
     name: Build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,20 +5,20 @@ jobs:
   build:
     if: github.repository_owner == 'hazelcast'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ '17' ]
-        architecture: [ 'x64' ]
-        distribution: [ 'temurin' ]
     name: Build
     steps:
       - uses: actions/checkout@v4
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
+        with:
+          config: ${{ github.workspace }}/.github/java-config.yml
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
-          architecture: ${{ matrix.architecture }}
-          distribution: ${{ matrix.distribution }}
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          architecture: 'x64'
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
           cache: 'maven'
 
       - name: Build with Maven

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -47,11 +47,16 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release-branch }}
           token: ${{ secrets.GH_PAT }}
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
+        with:
+          config: ${{ github.workspace }}/.github/java-config.yml
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
-          distribution: 'temurin'
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
           server-id: deploy-repository
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
-          distribution: 'adopt'
+          java-version: 17
+          distribution: 'temurin'
           server-id: deploy-repository
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -11,23 +11,23 @@ jobs:
   build:
     if: github.repository_owner == 'hazelcast'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ '17' ]
-        architecture: [ 'x64' ]
-        distribution: [ 'temurin' ]
-    name: Build SNAPSHOT version with JDK ${{ matrix.java }}
+    name: Build SNAPSHOT version
     steps:
       - uses: actions/checkout@v4
+      - name: Read Java Config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: java-config
+        with:
+          config: ${{ github.workspace }}/.github/java-config.yml
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
-          distribution: ${{ matrix.distribution }}
+          java-version: ${{ steps.java-config.outputs['java-version'] }}
+          distribution: ${{ steps.java-config.outputs['distribution'] }}
           server-id: deploy-repository
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          architecture: ${{ matrix.architecture }}
+          architecture: 'x64'
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           cache: 'maven'

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11' ]
+        java: [ '17' ]
         architecture: [ 'x64' ]
-        distribution: [ 'adopt' ]
+        distribution: [ 'temurin' ]
     name: Build SNAPSHOT version with JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4

--- a/hazelcast-jdbc-core/pom.xml
+++ b/hazelcast-jdbc-core/pom.xml
@@ -63,6 +63,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>3.25.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast-jdbc-core/pom.xml
+++ b/hazelcast-jdbc-core/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,15 +37,15 @@
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
+        <jdk.version>17</jdk.version>
         <hazelcast.version>5.3.6</hazelcast.version>
         <mockito.version>5.9.0</mockito.version>
-        <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
+        <maven.jacoco.plugin.version>0.8.11</maven.jacoco.plugin.version>
         <maven.findbugs.plugin.version>3.0.5</maven.findbugs.plugin.version>
         <maven.checkstyle.plugin.version>3.3.1</maven.checkstyle.plugin.version>
         <maven.sonar.plugin.version>5.1</maven.sonar.plugin.version>
         <maven.gpg.plugin.version>3.1.0</maven.gpg.plugin.version>
-        <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.6.3</maven.javadoc.plugin.version>
         <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
 
         <!-- needed for CheckStyle -->
@@ -126,7 +126,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>8.0.2</version>
+                <version>9.0.9</version>
                 <configuration>
                     <format>ALL</format>
                     <skipProvidedScope>true</skipProvidedScope>
@@ -169,6 +169,9 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.12.1</version>
+                    <configuration>
+                        <release>${jdk.version}</release>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
@@ -201,7 +204,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.5</version>
                     <configuration>
                         <excludedGroups>envs</excludedGroups>
                     </configuration>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -12,7 +12,6 @@
     <artifactId>smoke-test</artifactId>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Changes:
- Update release actions to use Java 17 JDK
   - centralised configuration for easier future updates
- Updated code level to 17

Fixes [HZ-4160](https://hazelcast.atlassian.net/browse/HZ-4160)

[HZ-4160]: https://hazelcast.atlassian.net/browse/HZ-4160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ