### PR TITLE
Fix `deploy-snapshot.yml` GitHub action

### DIFF
--- a/hazelcast-jdbc-core/pom.xml
+++ b/hazelcast-jdbc-core/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
+                <version>3.25.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
                         <execution>
                             <id>attach-sources</id>
                             <goals>
-                                <goal>jar</goal>
+                                <goal>jar-no-fork</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -231,6 +231,11 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>2.3.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -474,6 +479,7 @@
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
                             <execution>
+                                <id>attach-sources</id>
                                 <goals>
                                     <goal>jar-no-fork</goal>
                                 </goals>


### PR DESCRIPTION
[`deploy-snapshot.yml` consistently fails](https://github.com/hazelcast/hazelcast-jdbc/actions/workflows/deploy-snapshot.yml) with error:
```
Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.0:jar-no-fork (default) on project hazelcast-jdbc-core:
Presumably you have configured maven-source-plugn to execute twice times in your build. You have to configure a classifier for at  least on of them.
```

This is because two different `maven-source-plugin`s are configured with different `id`s and `goal`s.

Changes:
- Unify `maven-source-plugin` configurations
   - `id`s
   - `goal`s
- Specify `license-maven-plugin` version
   - resolves `'build.plugins.plugin.version' for org.codehaus.mojo:license-maven-plugin is missing.`
- Remove missing/duplicated `assertj-core` version declaration