### PR TITLE
Migrate GitHub actions from AdoptOpenJDK to Eclipse Temurin [HZ-4195]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         java: [ '11' ]
         architecture: [ 'x64' ]
-        distribution: [ 'adopt' ]
+        distribution: [ 'temurin' ]
     name: Build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
           server-id: deploy-repository
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         java: [ '11' ]
         architecture: [ 'x64' ]
-        distribution: [ 'adopt' ]
+        distribution: [ 'temurin' ]
     name: Build SNAPSHOT version with JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `setup-java` [documentation highlights that AdoptOpenJDK no longer receives security updates](https://github.com/actions/setup-java#:~:text=NOTE%3A%20AdoptOpenJDK%20got%20moved%20to%20Eclipse%20Temurin), and instead the Eclipse Temurin JDK should be used.

Fixes [HZ-4195](https://hazelcast.atlassian.net/browse/HZ-4195)

[HZ-4195]: https://hazelcast.atlassian.net/browse/HZ-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ