### PR TITLE
Use commit hash (not tag) for `action-read-yaml` action version specification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ github.event.inputs.release-branch }}
           token: ${{ secrets.GH_PAT }}
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Read Java Config
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d
         id: java-config
         with:
           config: ${{ github.workspace }}/.github/java-config.yml


### PR DESCRIPTION
Currently we are referencing a tag when specifying the version of the `action-read-yaml` action, which is potentially mutable.

[It was requested](https://github.com/hazelcast/hazelcast-mono/pull/1181#discussion_r1537109860) that the commit SHA be used instead, as per the [GitHub actions security hardening guide](https://github.com/hazelcast/hazelcast-mono/pull/1181#discussion_r1537109860).

Updated the version specification to the commit hash of the [currently used version](https://github.com/pietrobolcato/action-read-yaml/releases/tag/1.1.0) - i.e. no changes to the actual version of the action being used.