### PR TITLE
Update to 5.5.0 [DEX-192]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: ./mvnw clean package -V -B -P checkstyle,findbugs
+        run: ./mvnw --settings settings.xml clean package -V -B -P checkstyle,findbugs -Dhz.snapshot.internal.username=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }} -Dhz.snapshot.internal.password=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: ./mvnw -V -B install
+        run: ./mvnw --settings settings.xml -V -B install -Dhz.snapshot.internal.username=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }} -Dhz.snapshot.internal.password=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
 
       - name: Deploy OS with Maven
         run: ./mvnw -V -B deploy -Djdbc-release -DskipTests

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Open source:
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-jdbc</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -39,7 +39,7 @@ Enterprise (located in Hazelcast Maven repository):
     <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-jdbc-enterprise</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </dependency>
 </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>17</jdk.version>
-        <hazelcast.version>5.4.0</hazelcast.version>
+        <hazelcast.version>5.5.0-SNAPSHOT</hazelcast.version>
         <mockito.version>5.12.0</mockito.version>
         <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
         <maven.findbugs.plugin.version>3.0.5</maven.findbugs.plugin.version>
@@ -94,6 +94,17 @@
             <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>snapshot-internal</id>
+            <name>Hazelcast Internal Snapshots</name>
+            <url>https://repository.hazelcast.com/snapshot-internal/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+    <servers>
+        <server>
+            <id>snapshot-internal</id>
+            <username>${hz.snapshot.internal.username}</username>
+            <password>${hz.snapshot.internal.password}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
Updates dependency on Hazeclast to 5.5.0-SNAPSHOT, adds private repository with the snapshot, because they were removed from central snapshot repository.