### PR TITLE
Update JDBC_VERSION_MINOR to 5 [REL-294]

### DIFF
--- a/hazelcast-jdbc-core/src/main/java/com/hazelcast/jdbc/JdbcDataBaseMetadata.java
+++ b/hazelcast-jdbc-core/src/main/java/com/hazelcast/jdbc/JdbcDataBaseMetadata.java
@@ -46,7 +46,7 @@ import static java.util.stream.Collectors.joining;
 @SuppressWarnings("checkstyle:TrailingComment")
 public class JdbcDataBaseMetadata implements DatabaseMetaData {
     private static final int JDBC_VERSION_MAJOR = 5;
-    private static final int JDBC_VERSION_MINOR = 4;
+    private static final int JDBC_VERSION_MINOR = 5;
     private static final int DEFAULT_NUMBER_RADIX = 10;
 
     private final JdbcConnection connection;


### PR DESCRIPTION
This was left out when we did release 5.4.0. 
JDBC_VERSION_MINOR should have been updated at that point but was not
Need to do this now so we can release v5.5.0

Fixes [REL-294](https://hazelcast.atlassian.net/browse/REL-294)

[REL-294]: https://hazelcast.atlassian.net/browse/REL-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ