### PR TITLE
Remove `enableRSS` config param for `maven-checkstyle-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,6 @@
                             <configLocation>${checkstyle.configLocation}</configLocation>
                             <suppressionsLocation>${checkstyle.supressionsLocation}</suppressionsLocation>
                             <headerLocation>${checkstyle.headerLocation}</headerLocation>
-                            <enableRSS>false</enableRSS>
                             <linkXRef>false</linkXRef>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>


### PR DESCRIPTION
See https://github.com/hazelcast/hazelcast/pull/24738 etc, removed in https://github.com/apache/maven-checkstyle-plugin/pull/117