### PR TITLE
Update Hazelcast repository URL [DI-485]

### DIFF
--- a/hazelcast-jdbc-enterprise/pom.xml
+++ b/hazelcast-jdbc-enterprise/pom.xml
@@ -99,11 +99,11 @@
     <distributionManagement>
         <repository>
             <id>deploy-repository</id>
-            <url>https://hazelcast.jfrog.io/artifactory/release</url>
+            <url>https://repository.hazelcast.com/release</url>
         </repository>
         <snapshotRepository>
             <id>deploy-repository</id>
-            <url>https://hazelcast.jfrog.io/artifactory/snapshot</url>
+            <url>https://repository.hazelcast.com/snapshot</url>
         </snapshotRepository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
For consistency, all access should use the centralised Hazelcast repository URL.

Fixes: [DI-485](https://hazelcast.atlassian.net/browse/DI-485)

[DI-485]: https://hazelcast.atlassian.net/browse/DI-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ