### PR TITLE
Fix dependabot `reviewers` error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     schedule:
       interval: "daily"
       time: "02:00"
-    reviewers:
-      - ""
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
       time: "02:00"
-    reviewers:
-      - ""


### PR DESCRIPTION
See error on [this PR](https://github.com/hazelcast/hazelcast-jdbc/pull/459#issuecomment-2896256047):

> ### Reviewers
> The following users could not be added as reviewers: ``. Either the username does not exist or it does not have the correct permissions to be added as a reviewer.
> 
> Please fix the above issues or remove invalid values from `dependabot.yml`.



> The `reviewers` field in the `dependabot.yml` file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).