### PR TITLE
Migrate attribution-jdbc to new Central plugin [DI-627]

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -43,7 +43,7 @@ jobs:
           HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
     name: Build and release version
     env:
-      MAVEN_ARGS: --batch-mode --show-version
+      MAVEN_ARGS: --batch-mode --no-transfer-progress --show-version
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -6,6 +6,7 @@ on:
       - '[0-9]+.[0-9]+.z'
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -13,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build SNAPSHOT version
     env:
-      MAVEN_ARGS: --batch-mode --show-version
+      MAVEN_ARGS: --batch-mode --no-transfer-progress --show-version
     steps:
       - uses: actions/checkout@v5
       - name: Read Java Config

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Open source:
     <repository>
         <id>snapshot-repository</id>
         <name>Maven Snapshot Repository</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        <url>https://central.sonatype.com/repository/maven-snapshots</url>
         <releases>
             <enabled>false</enabled>
         </releases>

--- a/hazelcast-jdbc-core/pom.xml
+++ b/hazelcast-jdbc-core/pom.xml
@@ -27,6 +27,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <name>Hazelcast JDBC Driver Core</name>
     <artifactId>hazelcast-jdbc-core</artifactId>
 
     <properties>

--- a/hazelcast-jdbc-enterprise/pom.xml
+++ b/hazelcast-jdbc-enterprise/pom.xml
@@ -27,6 +27,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <name>Hazelcast JDBC Driver Enterprise</name>
     <artifactId>hazelcast-jdbc-enterprise</artifactId>
 
     <properties>

--- a/hazelcast-jdbc/pom.xml
+++ b/hazelcast-jdbc/pom.xml
@@ -27,6 +27,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <name>Hazelcast JDBC Driver</name>
     <artifactId>hazelcast-jdbc</artifactId>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <repository>
             <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -479,14 +479,20 @@
                     </plugin>
 
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>deploy-repository</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <!-- server id comes from settings.xml -->
+                            <publishingServerId>deploy-repository</publishingServerId>
+                            <!--
+                            wait until the artifacts are actually published automatically using 'autoPublish'.
+                            the default is `validated` which would then require manual publishing
+                            -->
+                            <waitUntil>published</waitUntil>
+                            <autoPublish>true</autoPublish>
+                            <checksums>required</checksums>
                         </configuration>
                     </plugin>
 
@@ -542,14 +548,10 @@
     </dependencies>
 
     <distributionManagement>
-        <repository>
-            <id>deploy-repository</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
         <snapshotRepository>
             <id>deploy-repository</id>
             <name>Maven2 Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
     </distributionManagement>


### PR DESCRIPTION
### Additional changes
1. ported changes from [attribution-maven-plugin#143](https://github.com/hazelcast/attribution-maven-plugin/pull/143)
2. `snapshot` deployment is not handled by the new plugin as project it has OS and EE parts. The EE module [pushes](https://github.com/hazelcast/hazelcast-jdbc/blob/hazelcast-jdbc-new-portal/hazelcast-jdbc-enterprise/pom.xml#L100) to JFrog so `snapshot` is deployed directly allowing EE module to override `<distributionManagement>`, otherwise, EE gets deployed to Central and fails, rightly so
3. added  missing project `<name>` in poms. Plugin doesn't complain about URL and description metadata (suspect its inherited from parent but `name` has to be unique)
4. added Maven option `--no-transfer-progress`
5. enabled and added `workflow_dispatch`  for [Deploy SNAPSHOT version](https://github.com/hazelcast/hazelcast-jdbc/actions/workflows/deploy-snapshot.yml) workflow

### Testing:
#### Snapshot
Version: `5.6.0-SNAPSHOT`
1. had to run [Deploy SNAPSHOT version](https://github.com/hazelcast/hazelcast-jdbc/actions/workflows/deploy-snapshot.yml) using `gh workflow run "Deploy SNAPSHOT version" --ref hazelcast-jdbc-new-portal` as `main` doesn't have `workflow_dispatch` yet
3. build completed with [success](https://github.com/hazelcast/hazelcast-jdbc/actions/runs/18033375216)
4. EE deployed to JFrog [here](https://hazelcast.jfrog.io/artifactory/snapshot/com/hazelcast/hazelcast-jdbc-enterprise/5.6.0-SNAPSHOT/)
5. OS deployed ok, example [maven-metadata.xml](https://central.sonatype.com/repository/maven-snapshots/com/hazelcast/hazelcast-jdbc/5.6.0-SNAPSHOT/maven-metadata.xml)
6. for completeness also ran `mvn dependency:get -Dartifact=com.hazelcast:hazelcast-jdbc:5.6.0-SNAPSHOT  -DremoteRepositories=https://central.sonatype.com/repository/maven-snapshots`

#### Release
Version: `1.1.1`
1. made temp changes on a separate branch ([diff](https://github.com/hazelcast/hazelcast-jdbc/compare/hazelcast-jdbc-new-portal...OSS-ONLY-hazelcast-jdbc-new-portal)) - only validate deploy and no EE
2. ran `deploy-snapshot.yml` workflow [successfully](https://github.com/hazelcast/hazelcast-jdbc/actions/runs/18033375216)
3. the project has dependency on Hazelcast `5.6.0-SNAPSHOT` so ran build against that first. Deployed fine but failed validation (`Dependencies to SNAPSHOT versions not allowed...`)
4. <img width="555" height="273" alt="image" src="https://github.com/user-attachments/assets/54196857-fb35-4a57-b273-43972f7bf502" />
5. then changed Hazelcast version to `5.5.0` and OS deployment validated [successfully](https://central.sonatype.com/publishing/deployments)
6. <img width="789" height="304" alt="image" src="https://github.com/user-attachments/assets/96d9aa7b-a2dc-4b27-a06e-55f393c65fa9" />

### Post tasks
- [ ] Remove staged deployment plus also cleanup previous errored ones

Fixes: [DI-627](https://hazelcast.atlassian.net/browse/DI-627)
