### PR TITLE
Fix Enterprise deployment [DI-627]

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -82,14 +82,14 @@ jobs:
           java -ea -cp smoke-test/target/smoke-test-${{ github.event.inputs.release-version }}.jar:hazelcast-jdbc-enterprise/target/hazelcast-jdbc-enterprise-${{ github.event.inputs.release-version }}.jar com.hazelcast.smoke.test.SmokeTestDriver 6702 $EE_CLUSTER_NAME
 
       - name: Deploy EE with Maven
-        run: ./mvnw --file hazelcast-jdbc-enterprise deploy -Djdbc-release -DskipTests -DskipStaging
+        run: ./mvnw --file hazelcast-jdbc-enterprise deploy -Djdbc-release -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.JFROG_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Deploy OS with Maven
-        run: ./mvnw deploy -Djdbc-release -DskipTests
+        run: ./mvnw deploy --activate-profiles release-central-staging -Djdbc-release -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -45,7 +45,8 @@ jobs:
           ./mvnw \
             deploy \
             -Djdbc-release \
-            -DskipTests
+            -DskipTests \
+            --activate-profiles release-central-staging
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,32 @@
         </profile>
 
         <profile>
+            <id>release-central-staging</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <!-- server id comes from settings.xml -->
+                            <publishingServerId>deploy-repository</publishingServerId>
+                            <!--
+                            wait until the artifacts are actually published automatically using 'autoPublish'.
+                            the default is `validated` which would then require manual publishing
+                            -->
+                            <waitUntil>published</waitUntil>
+                            <autoPublish>true</autoPublish>
+                            <checksums>required</checksums>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>release</id>
             <activation>
                 <property>
@@ -479,24 +505,6 @@
                     </plugin>
 
                     <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.9.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <!-- server id comes from settings.xml -->
-                            <publishingServerId>deploy-repository</publishingServerId>
-                            <!--
-                            wait until the artifacts are actually published automatically using 'autoPublish'.
-                            the default is `validated` which would then require manual publishing
-                            -->
-                            <waitUntil>published</waitUntil>
-                            <autoPublish>true</autoPublish>
-                            <checksums>required</checksums>
-                        </configuration>
-                    </plugin>
-
-                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
@@ -547,12 +555,4 @@
         </dependency>
     </dependencies>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>deploy-repository</id>
-            <name>Maven2 Snapshot Repository</name>
-            <url>https://central.sonatype.com/repository/maven-snapshots</url>
-            <uniqueVersion>false</uniqueVersion>
-        </snapshotRepository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
### Background

After https://github.com/hazelcast/hazelcast-jdbc/pull/502, Enterprise release deployment fails. The Central Publisher plugin always comes into play and tries to deploy to Maven Central and fails even though [maven-deploy-plugin](https://github.com/hazelcast/hazelcast-jdbc/blob/main/pom.xml#L196) has been defined

I tried couple of things but didn't work so raised ticket with Central support and they confirmed about using Maven profile:

> Having two publishing plugins in the same section of your POM always causes issues: there will be a race condition, and that fails the publishing pipeline intermittently, depending which plugin encounters an error first. The solution is, like you've mentioned, splitting these in different profiles. 

### Changes
1. moved `central-publishing-maven-plugin` under new Maven profile `release-central-staging` and also added `SNAPSHOT` handling
2. removed `<distributionManagement>` as not required
3. removed `-DskipStaging`
4. updated workflows to activate the new profile for OSS

### Testing

1. created temp Artifactory repo to test EE fully
2. made test changes in separate branch ([diff](https://github.com/hazelcast/hazelcast-jdbc/compare/fix-ee-deployment...TEST-fix-ee-deployment))

#### Snapshot
Version: `5.6.0-SNAPSHOT`

1. Build completed [successfully](https://github.com/hazelcast/hazelcast-jdbc/actions/runs/18102344303)
2. OS deployed ok, example [maven-metadata.xml](https://central.sonatype.com/repository/maven-snapshots/com/hazelcast/hazelcast-jdbc/5.6.0-SNAPSHOT/maven-metadata.xml)
4. JFrog EE deployed ok
4. <img width="295" height="218" alt="image" src="https://github.com/user-attachments/assets/be913ef2-e721-478d-a7a7-54a263fc43bd" />

#### Release
Version: `1.1.1`

1. Build completed [successfully](https://github.com/hazelcast/hazelcast-jdbc/actions/runs/18102689672)
2. OS validated ok
3. <img width="794" height="305" alt="image" src="https://github.com/user-attachments/assets/7517f182-c304-415d-811e-3fdbf5f370f8" />
4. JFrog EE deployed ok
5. <img width="225" height="141" alt="image" src="https://github.com/user-attachments/assets/84986f35-8699-4c71-a0bf-c7ef96dde189" />

### Post tasks

- [ ] cleanup staged deployments
- [ ] delete temp branch
- [ ] delete repo JFrog repo