### PR TITLE
Fix GitHub release creation token and mark as draft [REL-1868]

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
     services:
       hazelcast:
         image: hazelcast/hazelcast:latest-slim
@@ -46,6 +47,7 @@ jobs:
     name: Build and release version
     env:
       MAVEN_ARGS: --batch-mode --no-transfer-progress --show-version
+      TAG: v${{ github.event.inputs.release-version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -70,7 +72,7 @@ jobs:
         run: |
           ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
           git commit -am "Set version to ${{ github.event.inputs.release-version }}"
-          git tag v${{ github.event.inputs.release-version }}
+          git tag ${{ env.TAG }}
           ./mvnw clean install
 
       - name: Build and run smoke test
@@ -107,7 +109,7 @@ jobs:
         run: |
           ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
           git commit -am "Set version to ${{ github.event.inputs.next-snapshot-version }}"
-          git push origin v${{ github.event.inputs.release-version }}
+          git push origin ${{ env.TAG }}
           if [ -n "${{ github.event.inputs.release-branch }}" ]; then
             git push origin "${{ github.event.inputs.release-branch }}"
           else
@@ -117,9 +119,10 @@ jobs:
       - name: Upload OS binaries to the GitHub release
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
-          repo_token: ${{ secrets.GH_PAT }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: hazelcast-jdbc/target/hazelcast-jdbc-*.jar
           file_glob: true
-          tag: v${{ github.event.inputs.release-version }}
+          tag: ${{ env.TAG }}
+          release_name: ${{ env.TAG }}
           overwrite: true
           draft: true

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -117,7 +117,9 @@ jobs:
       - name: Upload OS binaries to the GitHub release
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
+          repo_token: ${{ secrets.GH_PAT }}
           file: hazelcast-jdbc/target/hazelcast-jdbc-*.jar
           file_glob: true
           tag: v${{ github.event.inputs.release-version }}
           overwrite: true
+          draft: true

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
           git commit -am "Set version to ${{ github.event.inputs.next-snapshot-version }}"
-          git push origin ${{ env.TAG }}
+          git push origin ${TAG}
           if [ -n "${{ github.event.inputs.release-branch }}" ]; then
             git push origin "${{ github.event.inputs.release-branch }}"
           else

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -119,7 +119,6 @@ jobs:
       - name: Upload OS binaries to the GitHub release
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: hazelcast-jdbc/target/hazelcast-jdbc-*.jar
           file_glob: true
           tag: ${{ env.TAG }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
           git commit -am "Set version to ${{ github.event.inputs.release-version }}"
-          git tag ${{ env.TAG }}
+          git tag ${TAG}
           ./mvnw clean install
 
       - name: Build and run smoke test


### PR DESCRIPTION
Release workflow [failed ](https://github.com/hazelcast/hazelcast-jdbc/actions/runs/25863231581/job/75998338662) first time round
1. Default GH token was the cause. Fixed by adding `write` permission and switched to `GITHUB_TOKEN`
2. Marked the release as `DRAFT` and passed `release_name:` (otherwise title is set to `DRAFT`)

**Testing**
1. Tested on test [branch](https://github.com/hazelcast/hazelcast-jdbc/blob/5.7.0-fixes/.github/workflows/deploy-release.yml) (skipped deploy/testing)
2. Created [v5.7.0](https://github.com/hazelcast/hazelcast-jdbc/releases/tag/untagged-ad57db3fb498c9d3e080) draft release

**Post merge**

- [x] Update release instructions to publish the GitHub release

Fixes [REL-1868](https://hazelcast.atlassian.net/browse/REL-1868)

[REL-1868]: https://hazelcast.atlassian.net/browse/REL-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ