### PR TITLE
Move to Hazelcast 6.0 development cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Open source:
     <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-jdbc</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </dependency>
 </dependencies>
 
@@ -93,7 +93,7 @@ Enterprise:
     <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-jdbc-enterprise</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </dependency>
 </dependencies>
 

--- a/hazelcast-jdbc-core/pom.xml
+++ b/hazelcast-jdbc-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-jdbc-root</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-jdbc-core/src/main/java/com/hazelcast/jdbc/JdbcDataBaseMetadata.java
+++ b/hazelcast-jdbc-core/src/main/java/com/hazelcast/jdbc/JdbcDataBaseMetadata.java
@@ -45,8 +45,8 @@ import static java.util.stream.Collectors.joining;
 
 @SuppressWarnings("checkstyle:TrailingComment")
 public class JdbcDataBaseMetadata implements DatabaseMetaData {
-    private static final int JDBC_VERSION_MAJOR = 5;
-    private static final int JDBC_VERSION_MINOR = 8;
+    private static final int JDBC_VERSION_MAJOR = 6;
+    private static final int JDBC_VERSION_MINOR = 0;
     private static final int DEFAULT_NUMBER_RADIX = 10;
 
     private final JdbcConnection connection;

--- a/hazelcast-jdbc-enterprise/pom.xml
+++ b/hazelcast-jdbc-enterprise/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-jdbc-root</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-jdbc/pom.xml
+++ b/hazelcast-jdbc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-jdbc-root</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>hazelcast-jdbc-root</artifactId>
     <packaging>pom</packaging>
 
-    <version>5.8.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <name>Hazelcast JDBC Driver Root</name>
     <description>Hazelcast JDBC Driver allows Java applications to connect to Hazelcast using the standard JDBC API</description>
     <url>http://github.com/hazelcast/hazelcast-jdbc</url>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-jdbc-root</artifactId>
-        <version>5.8.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smoke-test</artifactId>


### PR DESCRIPTION
Hazelcast is being updated to the next MAJOR development cycle `5.8.0 -> 6.0.0`
See https://github.com/hazelcast/hazelcast-mono/pull/7393